### PR TITLE
roll back to 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <maven-antrun.version>3.0.0</maven-antrun.version>
         <maven-assembly.version>3.3.0</maven-assembly.version>
         <maven-changes.version>2.12.1</maven-changes.version>
-        <maven-checkstyle.version>3.1.1</maven-checkstyle.version>
+        <maven-checkstyle.version>3.1.0</maven-checkstyle.version>
         <maven-clean.version>3.1.0</maven-clean.version>
         <maven-compiler.version>3.8.1</maven-compiler.version>
         <maven-dependency.version>3.1.2</maven-dependency.version>


### PR DESCRIPTION
this is a temporary workaround for #9 